### PR TITLE
Add Our Work portfolio section, AI-assisted dev card, and project guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Code78.net
+
+Marketing/portfolio site for **Code78 LLC** — a full-stack development, software, and IT-support shop. Single-page React app with a retro-terminal / cyberpunk aesthetic.
+
+## Where the code lives
+
+The React app is in **`code78.net/`** (Create React App), not the repo root. Run all npm commands from there:
+
+```bash
+cd code78.net
+npm install        # first time (add --legacy-peer-deps if you hit peer-dep errors)
+npm start          # dev server on http://localhost:3000
+npm run build      # production build
+```
+
+## Architecture
+
+- **React 19 + react-router-dom**, single page. Routes in `src/App.js` (`/`, `/planner`, 404).
+- **Home sections** (`src/pages/Home.js`): About → What We Do (Services) → Our Work (Portfolio) → Get In Touch. Each is a `Section` with a glitch `<h2>`.
+- **Content is data-driven — edit JSON, not components:**
+  - `src/data/services.json` — the "What We Do" cards.
+  - `src/data/portfolio.json` — the "Our Work" cards (`title`, `status` `live|wip`, `statusLabel`, `description`, `stack[]`, `url`, `linkLabel`, `credit`). Set `url: null` to show a muted "details_soon" instead of a link.
+  - `src/data/theme.json` — color palette, injected as CSS variables (`--color1`, `--terminal-bkg`, …) by `src/comp/ColorScheme.js`.
+- **Layout**: components in `src/comp/`, pages in `src/pages/`, CSS Modules in `src/CSS/`, fonts/media in `src/media/`.
+- **Aesthetic**: monospace (Kode Mono headings / Red Hat Mono body), amber-on-near-black, scanlines, glitch text, and `src/comp/CircuitBkg.js` — a hand-written procedural circuit-board canvas animation.
+
+## Conventions
+
+- Add a service → append to `services.json`. Add a portfolio project → append to `portfolio.json`.
+- **Keep content honest** — only advertise capabilities the team has actually shipped.
+
+## Workflow
+
+- Development happens on **`c-dev`** / **`d-dev`** branches; changes reach **`main`** via pull request. Don't commit directly to `main`.
+
+## Future work
+
+- **Replace the embedded Google Forms.** The Contact section (`src/pages/Home.js`) and the Planner (`src/pages/Planner.js`) currently embed color-inverted `forms.gle` iframes, which read as unprofessional for a dev shop. Build a first-party contact solution instead — `emailjs-com` is already a dependency and a `ContactForm` component is stubbed/commented in `Home.js`, so finishing that (or another owned form) is the intended path.

--- a/code78.net/src/App.js
+++ b/code78.net/src/App.js
@@ -14,6 +14,7 @@ function App() {
 
     const aboutRef = useRef(null);
     const serviceRef = useRef(null);
+    const workRef = useRef(null);
     const contactRef = useRef(null);
 
     // useEffect(() => {
@@ -53,9 +54,9 @@ function App() {
                 <CircuitBkg />
                 <CircuitBkg />
                 <div className="glass"></div>
-                <Header aboutRef={aboutRef} serviceRef={serviceRef} contactRef={contactRef} />
+                <Header aboutRef={aboutRef} serviceRef={serviceRef} workRef={workRef} contactRef={contactRef} />
                 <Routes>
-                    <Route path="/" element={<Home aboutRef={aboutRef} serviceRef={serviceRef} contactRef={contactRef} />} />
+                    <Route path="/" element={<Home aboutRef={aboutRef} serviceRef={serviceRef} workRef={workRef} contactRef={contactRef} />} />
                     <Route path="/planner" element={<Planner />} />
                     <Route path="*" element={<NotFound />} />
                 </Routes>

--- a/code78.net/src/CSS/portfolio.module.css
+++ b/code78.net/src/CSS/portfolio.module.css
@@ -1,0 +1,102 @@
+.grid {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    align-content: center;
+}
+.card {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--terminal-screen);
+    border-radius: 10px;
+    box-shadow: 0 0 10px var(--color1);
+    overflow: hidden;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+.card:hover {
+    box-shadow: 0 0 18px var(--color1);
+    transform: translateY(-3px);
+}
+.cardHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.6rem 1rem;
+    background-color: var(--terminal-bkg);
+}
+.cardTitle {
+    font-family: 'Kode Mono', monospace;
+    color: var(--color2);
+    font-size: 1.15rem;
+}
+.badge {
+    font-size: 0.6rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid currentColor;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+.live { color: var(--color2); }
+.wip { color: var(--color3); }
+.cardBody {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    padding: 1rem;
+}
+.desc {
+    font-size: 0.95rem;
+    line-height: 1.45;
+    font-weight: 400;
+}
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.tag {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border: 1px solid var(--nodeFilled);
+    border-radius: 4px;
+    color: var(--color1);
+    white-space: nowrap;
+}
+.cardFooter {
+    margin-top: auto;
+    padding-top: 0.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.liveLink {
+    text-decoration: none;
+    color: var(--color2);
+    font-size: 0.85rem;
+    transition: text-shadow 0.2s;
+}
+.liveLink:hover {
+    text-shadow: 0 0 8px var(--color2);
+}
+.muted {
+    color: var(--nodeFilled);
+    font-size: 0.85rem;
+}
+.credit {
+    font-size: 0.65rem;
+    opacity: 0.7;
+    font-weight: 400;
+}
+
+@media screen and (max-width: 650px) {
+    .grid {
+        gap: 1rem;
+    }
+}

--- a/code78.net/src/comp/CircuitBkg.js
+++ b/code78.net/src/comp/CircuitBkg.js
@@ -37,11 +37,12 @@ export default function CircuitBkg({ page }) {
     const LINE_WIDTH_PORTION = 0.2;
     const BLOOM_SIZE = 3;
     function canvasSetup(canvasElement) {
+        const rect = canvasElement.getBoundingClientRect();
+        if (!rect.width || !rect.height) return; // canvas not laid out yet; ResizeObserver will retry with real dimensions
         //Get column count
         colNodeCount = Math.max(Math.round(window.innerWidth / TARGET_COL_WIDTH), MIN_COL_NODE_COUNT);
         dividers = 2 * colNodeCount + 1;
         //Sizing canvas
-        const rect = canvasElement.getBoundingClientRect();
         dpr = window.devicePixelRatio || 1;
         canvasElement.width = rect.width * dpr;
         canvasElement.height = rect.height * dpr;
@@ -298,6 +299,11 @@ export default function CircuitBkg({ page }) {
     let lastFrameTime = null;
     const FRAME_DURATION = 1000 / 60;
     function updateAnimation(time) {
+        if (!ctx) {
+            // Canvas wasn't laid out at mount (0-size); wait for ResizeObserver to run canvasSetup.
+            requestAnimationFrame(updateAnimation);
+            return;
+        }
         if (!lastFrameTime) {
             lastFrameTime = time;
         }

--- a/code78.net/src/comp/Header.js
+++ b/code78.net/src/comp/Header.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
-export default function Header({aboutRef, serviceRef, contactRef}) {
+export default function Header({aboutRef, serviceRef, workRef, contactRef}) {
     const navigate = useNavigate();
     const location = useLocation();
     const scrollToSection = async elementRef => {
@@ -38,6 +38,7 @@ export default function Header({aboutRef, serviceRef, contactRef}) {
                 <nav>
                     <div className='navBtn glow' onClick={()=>scrollToSection(aboutRef)}>About</div>
                     <div className='navBtn glow' onClick={()=>scrollToSection(serviceRef)}>Services</div>
+                    <div className='navBtn glow' onClick={()=>scrollToSection(workRef)}>Work</div>
                     <div className='navBtn glow' onClick={()=>scrollToSection(contactRef)}>Contact</div>
                     <Link to="/planner" className='navBtn glow'>Planner</Link>
                 </nav>

--- a/code78.net/src/comp/Portfolio.js
+++ b/code78.net/src/comp/Portfolio.js
@@ -1,0 +1,29 @@
+import c from "../CSS/portfolio.module.css";
+import items from "../data/portfolio.json";
+
+export default function Portfolio() {
+    return (
+        <div className={c.grid}>
+            {items.map((p, i) => (
+                <div className={c.card} key={i}>
+                    <div className={c.cardHeader}>
+                        <span className={c.cardTitle}>{p.title}</span>
+                        <span className={`${c.badge} ${c[p.status]}`}>{p.statusLabel}</span>
+                    </div>
+                    <div className={c.cardBody}>
+                        <div className={c.desc}>{p.description}</div>
+                        <div className={c.tags}>
+                            {p.stack.map((t, j) => <span className={c.tag} key={j}>{t}</span>)}
+                        </div>
+                        <div className={c.cardFooter}>
+                            {p.url
+                                ? <a className={c.liveLink} href={p.url} target="_blank" rel="noreferrer">&gt; {p.linkLabel || "view_project"}</a>
+                                : <span className={c.muted}>&gt; details_soon</span>}
+                            {p.credit ? <span className={c.credit}>{p.credit}</span> : null}
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/code78.net/src/data/portfolio.json
+++ b/code78.net/src/data/portfolio.json
@@ -1,0 +1,32 @@
+[
+    {
+        "title": "DesktopToolkit",
+        "status": "live",
+        "statusLabel": "Released",
+        "description": "A PowerToys-style utility suite for Windows. A single tray host supervises modular tools — multi-monitor layout, taskbar control, and animated wallpapers — installable on the fly from a plugin catalog.",
+        "stack": ["C#", ".NET 9", "WPF", "Win32 IPC"],
+        "url": "https://github.com/C-McCarty/DesktopToolkit",
+        "linkLabel": "view_source",
+        "credit": "Built by Cameron McCarty"
+    },
+    {
+        "title": "MergeChess",
+        "status": "live",
+        "statusLabel": "Playable",
+        "description": "An original puzzle game that fuses match-3 with chess. Merge pieces up the promotion ladder, defend your kings from check, and clear the board across multiple game modes.",
+        "stack": ["JavaScript", "HTML5", "Custom Audio", "Game Design"],
+        "url": "https://mergechess.mccarty.cam/",
+        "linkLabel": "play_game",
+        "credit": "Built by Cameron McCarty"
+    },
+    {
+        "title": "CouponBook",
+        "status": "wip",
+        "statusLabel": "In Development",
+        "description": "A multi-role coupon marketplace linking customers, vendors, and distributors. Secure Firebase sign-in, role-based dashboards, and a hardened, documented REST API. In active development.",
+        "stack": ["React", "Express", "PostgreSQL", "Firebase Auth", "REST API"],
+        "url": null,
+        "linkLabel": "view_project",
+        "credit": null
+    }
+]

--- a/code78.net/src/data/services.json
+++ b/code78.net/src/data/services.json
@@ -12,6 +12,10 @@
         "content": "Design and development of custom software solutions tailored to streamline operations, improve efficiency, and support your unique business goals."
     },
     {
+        "title": "AI-Assisted Development",
+        "content": "We build with modern AI development tools integrated into our workflow, delivering quality software faster and more affordably without cutting corners."
+    },
+    {
         "title": "IT Support",
         "content": "Ongoing technical support, troubleshooting, and maintenance to keep your systems running smoothly."
     }

--- a/code78.net/src/pages/Home.js
+++ b/code78.net/src/pages/Home.js
@@ -3,8 +3,9 @@ import P from '../comp/P';
 import ContactForm from '../comp/ContactForm';
 import Carousel from '../comp/Carousel';
 import TabUI from '../comp/TabUI';
+import Portfolio from '../comp/Portfolio';
 
-export default function Home({aboutRef, serviceRef, contactRef}) {
+export default function Home({aboutRef, serviceRef, workRef, contactRef}) {
 
     return (
             <>
@@ -15,9 +16,13 @@ export default function Home({aboutRef, serviceRef, contactRef}) {
                     </Section>
                     <Section secRef={serviceRef}>
                         <h2 className='glitch' data-glitch="What We Do">What We Do</h2>
-                        {window.innerWidth > 1100 ? 
+                        {window.innerWidth > 1100 ?
                         <Carousel />
                         : <TabUI />}
+                    </Section>
+                    <Section secRef={workRef} expandable>
+                        <h2 className='glitch' data-glitch="Our Work">Our Work</h2>
+                        <Portfolio />
                     </Section>
                     {/* <Section secRef={contactRef}>
                         <h2 className='glitch' data-glitch="Get In Touch">Get In Touch</h2>


### PR DESCRIPTION
- New data-driven "Our Work" section: Portfolio component + portfolio.json with terminal-styled cards (status badges, stack tags, per-card link labels, personal-credit tags) and a "Work" nav item.
- Add "AI-Assisted Development" service card.
- Fix CircuitBkg white-screen crash when the canvas mounts at 0x0: guard canvasSetup and defer the animation loop until it has real dimensions.
- Add CLAUDE.md project guide (structure, commands, conventions, future work).